### PR TITLE
Add screen_size utility script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # Screen-sizer
+
+This repository provides a simple Python script to report the size of your terminal and the resolution of your display (if available).
+
+## Usage
+
+Run the script using Python:
+
+```bash
+python3 screen_size.py
+```
+
+The script will output the terminal size and, if Tkinter can access your display, the screen resolution.

--- a/screen_size.py
+++ b/screen_size.py
@@ -1,0 +1,43 @@
+import os
+
+try:
+    from tkinter import Tk
+except Exception:
+    Tk = None
+
+def get_terminal_size():
+    try:
+        return os.get_terminal_size()
+    except OSError:
+        return None
+
+def get_screen_size():
+    if Tk is None:
+        return None
+    try:
+        root = Tk()
+        root.withdraw()
+        width = root.winfo_screenwidth()
+        height = root.winfo_screenheight()
+        root.destroy()
+        return width, height
+    except Exception:
+        return None
+
+def main():
+    term = get_terminal_size()
+    screen = get_screen_size()
+
+    if term:
+        print(f"Terminal size: {term.columns}x{term.lines}")
+    else:
+        print("Terminal size: unavailable")
+
+    if screen:
+        width, height = screen
+        print(f"Screen resolution: {width}x{height}")
+    else:
+        print("Screen resolution: unavailable")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add simple Python script for reporting terminal and screen size
- document usage in README

## Testing
- `python3 screen_size.py`


------
https://chatgpt.com/codex/tasks/task_e_686808469060832483dd2d1c4d7614f7