### PR TITLE
Add basic screen-size web page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 # Screen-sizer
+
+This repository now includes a small web page for viewing your screen size in the browser, along with the original Python script.
+
+## Website Usage
+
+Open `index.html` directly in your browser or serve it with a simple HTTP server:
+
+```bash
+python3 -m http.server
+```
+
+Navigate to `http://localhost:8000` and the page will display your current window size and screen resolution. Resize the browser window to see the values update.
+
+## Python Script
+
+You can still run the command-line script if you prefer:
+
+```bash
+python3 screen_size.py
+```
+
+The script prints the terminal size and, if Tkinter can access your display, the screen resolution.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Screen Sizer</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; padding-top: 50px; }
+        #resolution { font-size: 1.2em; }
+    </style>
+</head>
+<body>
+    <h1>Screen Sizer</h1>
+    <p id="resolution">Loading...</p>
+    <script>
+        function updateResolution() {
+            const w = window.innerWidth;
+            const h = window.innerHeight;
+            const sw = window.screen.width;
+            const sh = window.screen.height;
+            const text = `Window size: ${w} x ${h} (Screen: ${sw} x ${sh})`;
+            document.getElementById('resolution').textContent = text;
+        }
+        window.addEventListener('resize', updateResolution);
+        updateResolution();
+    </script>
+</body>
+</html>

--- a/screen_size.py
+++ b/screen_size.py
@@ -1,0 +1,43 @@
+import os
+
+try:
+    from tkinter import Tk
+except Exception:
+    Tk = None
+
+def get_terminal_size():
+    try:
+        return os.get_terminal_size()
+    except OSError:
+        return None
+
+def get_screen_size():
+    if Tk is None:
+        return None
+    try:
+        root = Tk()
+        root.withdraw()
+        width = root.winfo_screenwidth()
+        height = root.winfo_screenheight()
+        root.destroy()
+        return width, height
+    except Exception:
+        return None
+
+def main():
+    term = get_terminal_size()
+    screen = get_screen_size()
+
+    if term:
+        print(f"Terminal size: {term.columns}x{term.lines}")
+    else:
+        print("Terminal size: unavailable")
+
+    if screen:
+        width, height = screen
+        print(f"Screen resolution: {width}x{height}")
+    else:
+        print("Screen resolution: unavailable")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create an `index.html` page that reports the browser window and screen dimensions
- update README with instructions for serving the page alongside the existing CLI script

## Testing
- `python3 screen_size.py`
- `python3 -m http.server` (manually started and terminated)

------
https://chatgpt.com/codex/tasks/task_e_686808469060832483dd2d1c4d7614f7