### PR TITLE
Add screen size website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # Screen-sizer
+
+This repository provides a simple tool to report the size of your terminal or browser window. Originally it included only a Python script, but you can now view the information directly in your browser using the included web page.
+
+## Usage
+
+Run the script using Python:
+
+```bash
+python3 screen_size.py
+```
+
+The script will output the terminal size and, if Tkinter can access your display, the screen resolution.
+
+## Website
+
+Open `index.html` in any modern web browser. The page will display the current
+window size and your screen's resolution. Resizing the browser window updates
+the values automatically.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Screen Sizer</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        code { background: #f4f4f4; padding: 2px 4px; }
+    </style>
+</head>
+<body>
+    <h1>Screen Sizer</h1>
+    <p id="window-size">Window size: </p>
+    <p id="screen-size">Screen resolution: </p>
+
+    <script>
+        function updateSize() {
+            var winWidth = window.innerWidth;
+            var winHeight = window.innerHeight;
+            document.getElementById('window-size').textContent =
+                'Window size: ' + winWidth + 'x' + winHeight;
+
+            var screenWidth = window.screen.width;
+            var screenHeight = window.screen.height;
+            document.getElementById('screen-size').textContent =
+                'Screen resolution: ' + screenWidth + 'x' + screenHeight;
+        }
+        window.addEventListener('load', updateSize);
+        window.addEventListener('resize', updateSize);
+    </script>
+</body>
+</html>

--- a/screen_size.py
+++ b/screen_size.py
@@ -1,0 +1,43 @@
+import os
+
+try:
+    from tkinter import Tk
+except Exception:
+    Tk = None
+
+def get_terminal_size():
+    try:
+        return os.get_terminal_size()
+    except OSError:
+        return None
+
+def get_screen_size():
+    if Tk is None:
+        return None
+    try:
+        root = Tk()
+        root.withdraw()
+        width = root.winfo_screenwidth()
+        height = root.winfo_screenheight()
+        root.destroy()
+        return width, height
+    except Exception:
+        return None
+
+def main():
+    term = get_terminal_size()
+    screen = get_screen_size()
+
+    if term:
+        print(f"Terminal size: {term.columns}x{term.lines}")
+    else:
+        print("Terminal size: unavailable")
+
+    if screen:
+        width, height = screen
+        print(f"Screen resolution: {width}x{height}")
+    else:
+        print("Screen resolution: unavailable")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `index.html` website showing window and screen size
- document usage in README

## Testing
- `python3 screen_size.py`


------
https://chatgpt.com/codex/tasks/task_e_686808469060832483dd2d1c4d7614f7